### PR TITLE
Fix #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url" : "https://github.com/jaxry/bubblechan.git"
   },
   "scripts": {
-    "build": "gcc force_direct.c -o ./bin/force_direct -lm -O3"
+    "build": "mkdir ./bin && gcc force_direct.c -o ./bin/force_direct -lm -O3 -std=gnu99"
   },
   "dependencies": {
     "express": "latest",


### PR DESCRIPTION
GCC needs the source to be built with -std=gnu99 (or -std=c99) and needs the `bin' directory to exist.
